### PR TITLE
Make blockchain_follower pluggable

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -1,12 +1,5 @@
 %% -*- erlang -*-
 [
- {blockchain_follower,
-  [
-   {follower_modules, []},
-   {ledger_required, false},
-   {sync_mode, false}
-  ]},
-
  {kernel,
   [
    %% force distributed erlang to only run on localhost

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,6 +1,17 @@
 %% -*- erlang -*-
 [
- {blockchain_follower, []},
+ {blockchain_follower,
+  [
+   {follower_modules, []},
+   {ledger_required, false},
+   {sync_mode, false}
+  ]},
+
+ {kernel,
+  [
+   %% force distributed erlang to only run on localhost
+   {inet_dist_use_interface, {127,0,0,1}}
+  ]},
  {lager,
   [
    {suppress_supervisor_start_stop, true},
@@ -18,9 +29,9 @@
   [
    {honor_assumed_valid, true},
 
-   {assumed_valid_block_height, 131279},
+   {assumed_valid_block_height, 339302},
    {assumed_valid_block_hash,
-    <<137,111,88,159,78,114,190,73,96,48,119,34,248,152,255,63,157,20,94,82,200,244,236,237,209,131,77,36,25,54,200,15>>},
+    <<122,35,177,244,9,101,130,149,74,211,23,29,24,238,14,103,202,0,187,245,25,153,205,134,157,165,78,19,51,124,29,53>>},
    {port, 44158},
    {key, undefined},
    {base_dir, "data"},
@@ -47,6 +58,7 @@
     [
      {max_open_files, 128},
      {compaction_style, universal},
+     {block_based_table_options, [{cache_index_and_filter_blocks, true}]},
      {memtable_memory_budget, 33554432},  % 32MB
      {arena_block_size, 131072}, % 128k
      {write_buffer_size, 131072},

--- a/src/bf_follower.erl
+++ b/src/bf_follower.erl
@@ -2,7 +2,7 @@
 
 -callback requires_sync() -> boolean().
 -callback requires_ledger() -> boolean().
--callback follower_height() -> pos_integer().
+-callback follower_height(State::any()) -> pos_integer().
 -callback init() -> {ok, State::any()} | {error, term()}.
 -callback load_chain(blockchain:blockchain(), State::any()) -> {ok, NewState::any()}.
 -callback load(Hash::binary(),
@@ -81,7 +81,7 @@ handle_info({blockchain_event, {add_block, Hash, Sync, Ledger}},
     {ok, Block} = blockchain:get_block(Hash, Chain),
     MaybePlaybackBlocks =
         fun() ->
-           Height = FollowerMod:follower_height(),
+           Height = FollowerMod:follower_height(State#state.follower_state),
            BlockHeight = blockchain_block:height(Block),
            case BlockHeight of
                X when X == Height + 1 ->

--- a/src/bf_follower.erl
+++ b/src/bf_follower.erl
@@ -1,19 +1,35 @@
 -module(bf_follower).
 
+-callback init() -> {ok, State::any()} | {error, term()}.
+-callback load_chain(blockchain:blockchain(), State::any()) -> {ok, NewState::any()}.
+-callback load(Hash::binary(),
+               blockchain:block(),
+               Sync::boolean(),
+               blockchain_ledger_v1:ledger(),
+               State::any()) -> {ok, NewState::any()}.
+-callback terminate(State::any()) -> ok.
+
+-optional_callbacks([terminate/1]).
+
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0,
+         get_height/0, put_height/1,
+         get_cache/1, put_cache/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
+-define(CACHE, bf_cache).
+-define(CACHE_HEIGHT, bf_height).
 
 -record(state,
         {
-         chain
+         chain=undefined :: undefined | blockchain:blockchain(),
+         followers :: [{Module::atom(), State::any()}]
         }).
 
 %%%===================================================================
@@ -23,19 +39,38 @@
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
+get_height() ->
+    get_cache(?CACHE_HEIGHT, 2).
+
+put_height(Height) ->
+    put_cache({?CACHE_HEIGHT, Height}).
+
+get_cache(Key) ->
+    ets:lookup(?CACHE, Key).
+
+get_cache(Key, N) ->
+    ets:lookup_element(?CACHE, Key, N).
+
+put_cache(Entry) ->
+    ets:insert(?CACHE, [Entry]).
+
+
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
 
 init([]) ->
-    case blockchain_worker:blockchain() of
-        undefined ->
-            erlang:send_after(500, self(), chain_check),
-            {ok, #state{}};
-        Chain ->
-            ok = blockchain_event:add_handler(self()),
-            {ok, #state{chain = Chain}}
-    end.
+    ok = register_blockchain_event_handler(self()),
+    ets:new(?CACHE, [public, named_table, {read_concurrency, true}]),
+    BaseDir = application:get_env(blockchain, base_dir, "data"),
+    FollowerMods = application:get_env(blockchain_follower, follower_modules, []),
+    Followers = lists:map(fun(M) ->
+                                  {ok, S} = M:init(),
+                                  {M, S}
+                            end, FollowerMods),
+    blockchain_worker:load(BaseDir, "update"),
+
+    {ok, #state{followers=Followers}}.
 
 handle_call(_Request, _From, State) ->
     lager:warning("unexpected call ~p from ~p", [_Request, _From]),
@@ -46,46 +81,102 @@ handle_cast(_Msg, State) ->
     lager:warning("unexpected cast ~p", [_Msg]),
     {noreply, State}.
 
-handle_info({blockchain_event, {add_block, Hash, _Sync, Ledger}},
-            #state{chain = Chain} = State) ->
+handle_info({blockchain_event, From, {new_chain, Chain}}, State=#state{followers=Followers}) ->
+    Followers = lists:map(fun({M, S}) ->
+                                  {ok, NS} = M:load_chain(Chain, S),
+                                  {M, NS}
+                          end, State#state.followers),
+    acknowledge_blockchain_event(From),
+    {noreply, State#state{chain=Chain, followers=Followers}};
 
-    %%% START TODO
-
-    %% Here, you should add the whatever code you would like called at
-    %% each block sync.  The code before the END comment is very
-    %% basic, to give you an idea of the kind of thing that can be
-    %% done here.  For more advanced examples, please see the miner
-    %% repository.
-    %% e.g. https://github.com/helium/miner/blob/master/src/miner.erl#L497
-    %%      https://github.com/helium/miner/blob/master/src/miner_consensus_mgr.erl#L364
+handle_info({blockchain_event, From, {add_block, Hash, Sync, Ledger}},
+            State=#state{chain=Chain, followers=Followers0}) ->
 
     {ok, Block} = blockchain:get_block(Hash, Chain),
-    {ok, LedgerHeight} = blockchain_ledger_v1:current_height(Ledger),
+    Height = get_height(),
     BlockHeight = blockchain_block:height(Block),
-    Txns = types(blockchain_block:transactions(Block)),
+    LedgerRequired = application:get_env(blockchain_follower, ledger_required, true),
 
-    lager:info("added block ~p (ledger height ~p) with txns: ~p",
-               [BlockHeight, LedgerHeight, Txns]),
+    Followers1 =
+        case BlockHeight of
+            X when X == Height + 1 ->
+                %% as expected, just continue below
+                Followers0;
+        X when X =< Height ->
+                lager:info("ignoring block ~p", [BlockHeight]),
+                %% already have these
+                acknowledge_blockchain_event(From),
+                %% throws count as early returns from gen_servers
+                throw({noreply, State});
+        X when X > Height + 1 ->
+                MapFollowers =
+                    fun(MissingHeight, FS) ->
+                            {ok, MissingBlock} = blockchain:get_block(MissingHeight, Chain),
+                            MissingHash = blockchain_block:hash_block(MissingBlock),
+                            {ok, MissingLedger} = case LedgerRequired of
+                                                      true ->
+                                                          blockchain:ledger_at(MissingHeight, Chain);
+                                                      false ->
+                                                          {ok, undefined}
+                                                  end,
+                            lists:map(fun({M, S}) ->
+                                              {ok, NS} = M:load(MissingHash, MissingBlock, true, MissingLedger, S),
+                                              {M, NS}
+                                      end, FS)
+                    end,
+                %% missing some blocks, try to obtain them
+                BlockHeights = lists:seq(Height + 1, BlockHeight - 1),
+                lager:info("trying to absorb missing blocks [~p..~p]", [hd(BlockHeights), lists:last(BlockHeights)]),
+                lists:foldl(MapFollowers, Followers0, BlockHeights)
+        end,
 
-    %%% END TODO
+    Followers2 = lists:map(fun({M, S}) ->
+                                   {ok, NS} = M:load(Hash, Block, Sync, Ledger, S),
+                                   {M, NS}
+                           end, Followers1),
 
+    acknowledge_blockchain_event(From),
+    {noreply, State#state{followers=Followers2}};
+
+handle_info({blockchain_event, From, Other}, State=#state{}) ->
+    lager:info("Ignoring blockchain event: ~p", [Other]),
+    acknowledge_blockchain_event(From),
     {noreply, State};
-handle_info(chain_check, _State) ->
-    {ok, State1} = init([]),
-    {noreply, State1};
+
 handle_info(_Info, State) ->
     lager:warning("unexpected message ~p", [_Info]),
     {noreply, State}.
 
-terminate(_Reason, _State) ->
-    ok.
+terminate(Reason, State=#state{}) ->
+    lists:foreach(fun({M, S}) ->
+                          case erlang:function_exported(M, terminate, 2) of
+                              true->
+                                  M:terminate(Reason, S);
+                              false ->
+                                  ok
+                          end
+                   end, State#state.followers).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
 
-types(L) ->
-    lists:map(fun blockchain_txn:type/1, L).
+%%
+%% Internal
+%%
+
+register_blockchain_event_handler(Pid) ->
+    case application:get_env(blockchain_follower, sync_mode, false) of
+        true ->
+            blockchain_event:add_sync_handler(Pid);
+        false ->
+            blockchain_event:add_handler(Pid)
+    end.
+
+acknowledge_blockchain_event(From) ->
+    case application:get_env(blockchain_follower, sync_mode, false) of
+        true ->
+            blockchain_event:acknowledge(From);
+        false ->
+            ok
+    end.

--- a/src/bf_follower.erl
+++ b/src/bf_follower.erl
@@ -5,11 +5,11 @@
 -callback follower_height(State::any()) -> pos_integer().
 -callback init() -> {ok, State::any()} | {error, term()}.
 -callback load_chain(blockchain:blockchain(), State::any()) -> {ok, NewState::any()}.
--callback load(Hash::binary(),
-               blockchain:block(),
-               Sync::boolean(),
-               blockchain_ledger_v1:ledger(),
-               State::any()) -> {ok, NewState::any()}.
+-callback load_block(Hash::binary(),
+                     blockchain:block(),
+                     Sync::boolean(),
+                     blockchain_ledger_v1:ledger() | undefined,
+                     State::any()) -> {ok, NewState::any()}.
 -callback terminate(State::any()) -> ok.
 
 -optional_callbacks([terminate/1]).
@@ -105,7 +105,7 @@ handle_info({blockchain_event, {add_block, Hash, Sync, Ledger}},
                                                                  false ->
                                                                      {ok, undefined}
                                                              end,
-                                       FollowerMod:load(MissingHash, MissingBlock, true, MissingLedger, FS)
+                                       FollowerMod:load_block(MissingHash, MissingBlock, true, MissingLedger, FS)
                                end, {ok, State#state.follower_state}, BlockHeights)
            end
         end,
@@ -114,7 +114,7 @@ handle_info({blockchain_event, {add_block, Hash, Sync, Ledger}},
         {error, already_loaded} ->
             {noreply, State};
         {ok, FollowerState} ->
-            {ok, NewFollowerState} = FollowerMod:load(Hash, Block, Sync, Ledger, FollowerState),
+            {ok, NewFollowerState} = FollowerMod:load_block(Hash, Block, Sync, Ledger, FollowerState),
             {noreply, State#state{follower_state=NewFollowerState}}
     end;
 

--- a/src/blockchain_follower.app.src
+++ b/src/blockchain_follower.app.src
@@ -1,13 +1,15 @@
 {application, blockchain_follower,
- [{description, "basic blockchain following application"},
+ [{description, "Callback based blockchain follower application"},
   {vsn, "0.1.0"},
   {registered, []},
   {mod, {blockchain_follower_app, []}},
   {applications,
    [kernel,
     stdlib,
+    syntax_tools,
+    compiler,
     lager,
-    rocksdb
+    clique
    ]},
   {included_applications, [blockchain]},
   {env,[]},


### PR DESCRIPTION
This adds a follower module list and replay behavior for missing
blocks. A behavior is declared that follower modules are expected to
implement.